### PR TITLE
SingleParamParser使用時、1つのセルにタグと文字列を書くと置換パラメータがnullの場合に"null"が出力される

### DIFF
--- a/src/main/java/org/bbreak/excella/reports/tag/SingleParamParser.java
+++ b/src/main/java/org/bbreak/excella/reports/tag/SingleParamParser.java
@@ -145,6 +145,9 @@ public class SingleParamParser extends ReportsTagParser<Object> {
         if ( paramValues.size() > 1) {
             StringBuilder builder = new StringBuilder();
             for ( Object object : paramValues) {
+                if ( object == null) {
+                    continue;
+                }
                 if ( object instanceof Date) {
                     SimpleDateFormat sdf = new SimpleDateFormat( "yyyy/MM/dd");
                     builder.append( sdf.format( object));


### PR DESCRIPTION
テンプレート上の1セルに```foo${tag}bar```と設定した場合、置換パラメータ```tag```の値が```null```である場合に```foonullbar```と出力されてしまいます。

置換パラメータが```null```の場合には空文字を出力するように修正しましたのでご確認ください。
