### PR TITLE
Bump POI to 4.1.1 and fix warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
   	<dependency>
   		<groupId>org.bbreak.excella</groupId>
   		<artifactId>excella-core</artifactId>
-  		<version>1.12</version>
+  		<version>2.0</version>
   	</dependency>
   	<dependency>
   		<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <name>excella-reports</name>
 
   <properties>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/bbreak/excella/reports/listener/BreakAdapter.java
+++ b/src/main/java/org/bbreak/excella/reports/listener/BreakAdapter.java
@@ -65,7 +65,7 @@ public class BreakAdapter extends ReportProcessAdaptor {
         for ( int colIndex = firstColNum; colIndex <= lastColNum; colIndex++) {
             Cell cell = row.getCell( colIndex);
             if ( cell != null) {
-                if ( cell.getCellTypeEnum() == CellType.STRING && cell.getStringCellValue().contains( BreakParamParser.DEFAULT_TAG)) {
+                if ( cell.getCellType() == CellType.STRING && cell.getStringCellValue().contains( BreakParamParser.DEFAULT_TAG)) {
                     // 改ページを挿入
                     if ( isInMergedRegion( sheet, row, cell)) {
                         setRowBreakMergedRegion( sheet, row, cell);

--- a/src/main/java/org/bbreak/excella/reports/listener/RemoveAdapter.java
+++ b/src/main/java/org/bbreak/excella/reports/listener/RemoveAdapter.java
@@ -90,7 +90,7 @@ public class RemoveAdapter extends ReportProcessAdaptor {
                 for ( int colIndex = firstColNum; colIndex <= lastColNum; colIndex++) {
                     Cell cell = row.getCell( colIndex);
                     if ( cell != null) {
-                        if ( cell.getCellTypeEnum() == CellType.STRING && cell.getStringCellValue().contains( RemoveParamParser.DEFAULT_TAG)) {
+                        if ( cell.getCellType() == CellType.STRING && cell.getStringCellValue().contains( RemoveParamParser.DEFAULT_TAG)) {
                             // タグのパラメータを取得
                             String[] paramArray = getStrParam( sheet, rowIndex, colIndex);
 
@@ -113,7 +113,7 @@ public class RemoveAdapter extends ReportProcessAdaptor {
                             colIndex--;
                         }
                         // 制御行の処理
-                        if ( isControlRow( sheet, sheetParser, row, cell)) {
+                        else if ( isControlRow( sheet, sheetParser, row, cell)) {
                             removeControlRow( sheet, rowIndex);
                             isRowFlag = true;
                             break;
@@ -166,13 +166,13 @@ public class RemoveAdapter extends ReportProcessAdaptor {
             removeRegion( sheet, rowIndex, colIndex);
             if ( paramArray.length > 1) {
                 Row removeRow = sheet.getRow( rowIndex);
-                if( removeRow != null){
+                if ( removeRow != null) {
                     Cell removeCell = removeRow.getCell( colIndex);
-                    if( removeCell != null){
-                        removeRow.removeCell( removeCell);                        
+                    if ( removeCell != null) {
+                        removeRow.removeCell( removeCell);
                     }
                 }
-                
+
                 // セル削除後のシフト方向
                 String direction = paramArray[1];
                 if ( direction.equals( LEFT)) {

--- a/src/main/java/org/bbreak/excella/reports/tag/BlockColRepeatParamParser.java
+++ b/src/main/java/org/bbreak/excella/reports/tag/BlockColRepeatParamParser.java
@@ -530,7 +530,7 @@ public class BlockColRepeatParamParser extends ReportsTagParser<Object[]> {
 
             // タグ除去
             if ( removeTag) {
-                tagCell.setCellType( CellType.BLANK);
+                tagCell.setBlank();
             }
 
             // リターン情報セット

--- a/src/main/java/org/bbreak/excella/reports/tag/BlockRowRepeatParamParser.java
+++ b/src/main/java/org/bbreak/excella/reports/tag/BlockRowRepeatParamParser.java
@@ -494,7 +494,7 @@ public class BlockRowRepeatParamParser extends ReportsTagParser<Object[]> {
 
             // タグ除去
             if ( removeTag) {
-                tagCell.setCellType( CellType.BLANK);
+                tagCell.setBlank();
             }
 
             // 解析結果

--- a/src/main/java/org/bbreak/excella/reports/tag/ImageParamParser.java
+++ b/src/main/java/org/bbreak/excella/reports/tag/ImageParamParser.java
@@ -32,7 +32,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.CreationHelper;
@@ -173,7 +172,7 @@ public class ImageParamParser extends ReportsTagParser<String> {
             // 結合セルに含まれるか
             if ( ReportsUtil.getMergedAddress( sheet, tagCell.getRowIndex(), tagCell.getColumnIndex()) != null) {
                 CellStyle cellStyle = tagCell.getCellStyle();
-                tagCell.setCellType( CellType.BLANK);
+                tagCell.setBlank();
                 tagCell.setCellStyle( cellStyle);
             } else {
                 tagCell = new CellClone( tagCell);

--- a/src/main/java/org/bbreak/excella/reports/tag/SingleParamParser.java
+++ b/src/main/java/org/bbreak/excella/reports/tag/SingleParamParser.java
@@ -186,7 +186,7 @@ public class SingleParamParser extends ReportsTagParser<Object> {
     @Override
     public boolean isParse( Sheet sheet, Cell tagCell) throws ParseException {
         // 文字列かつ、タグを含むセルの場合は処理対象
-        if ( tagCell.getCellTypeEnum() == CellType.STRING) {
+        if ( tagCell.getCellType() == CellType.STRING) {
             String cellTag = TagUtil.getTag( tagCell.getStringCellValue());
             if ( cellTag.endsWith( getTag())) {
                 return true;

--- a/src/main/java/org/bbreak/excella/reports/util/ReportsUtil.java
+++ b/src/main/java/org/bbreak/excella/reports/util/ReportsUtil.java
@@ -496,7 +496,7 @@ public final class ReportsUtil {
             for ( int bColIndex = bStartColIndex; bColIndex <= bEndColIndex; bColIndex++) {
                 Row row = sheet.getRow( bRowIndex);
                 if ( row != null && row.getCell( bColIndex) != null) {
-                    blockCellType[rowIdx][colIdx] = row.getCell( bColIndex).getCellTypeEnum();
+                    blockCellType[rowIdx][colIdx] = row.getCell( bColIndex).getCellType();
                 } else {
                     blockCellType[rowIdx][colIdx] = CellType.BLANK;
                 }

--- a/src/test/java/org/bbreak/excella/reports/ReportsTestUtil.java
+++ b/src/test/java/org/bbreak/excella/reports/ReportsTestUtil.java
@@ -255,7 +255,7 @@ public class ReportsTestUtil {
                     Iterator<Cell> cellIterator = row.cellIterator();
                     while ( cellIterator.hasNext()) {
                         Cell cell = cellIterator.next();
-                        if ( cell.getCellTypeEnum() != CellType.BLANK) {
+                        if ( cell.getCellType() != CellType.BLANK) {
                             lastRowIndex = row.getRowNum();
                             break;
                         }
@@ -398,9 +398,9 @@ public class ReportsTestUtil {
         }
 
         // 型
-        if ( expected.getCellTypeEnum() != actual.getCellTypeEnum()) {
-            errors.add( new CheckMessage( "型[" + "セル(" + expected.getRowIndex() + "," + expected.getColumnIndex() + ")" + "]", getCellTypeString( expected.getCellTypeEnum()),
-                getCellTypeString( actual.getCellTypeEnum())));
+        if ( expected.getCellType() != actual.getCellType()) {
+            errors.add( new CheckMessage( "型[" + "セル(" + expected.getRowIndex() + "," + expected.getColumnIndex() + ")" + "]", getCellTypeString( expected.getCellType()),
+                getCellTypeString( actual.getCellType())));
             throw new ReportsCheckException( errors);
         }
 
@@ -721,7 +721,7 @@ public class ReportsTestUtil {
         String value = null;
 
         if ( cell != null) {
-            switch ( cell.getCellTypeEnum()) {
+            switch ( cell.getCellType()) {
                 case BLANK:
                     value = cell.getStringCellValue();
                     break;

--- a/src/test/java/org/bbreak/excella/reports/util/ReportsUtilTest.java
+++ b/src/test/java/org/bbreak/excella/reports/util/ReportsUtilTest.java
@@ -506,7 +506,7 @@ public class ReportsUtilTest extends ReportsWorkbookTest {
                         fail();
                     }
                 } else {
-                    assertTrue( sheet.getRow( r) == null || sheet.getRow( r).getCell( c) == null || sheet.getRow( r).getCell( c).getCellTypeEnum() == CellType.BLANK);
+                    assertTrue( sheet.getRow( r) == null || sheet.getRow( r).getCell( c) == null || sheet.getRow( r).getCell( c).getCellType() == CellType.BLANK);
                 }
 
             }


### PR DESCRIPTION
Changes proposed in this pull request:
- Bump Apache POI from 3.16 to 4.1.1
    - excella-core/excella-core#28 を前提としているため、excella-coreリリース後のバージョンを設定する必要があります
- Fix deprecated warnings
- Bump target version of Java from 1.7 to 1.8
    - POI 4.0+ requires Java 8

